### PR TITLE
Fix md5 hash for utf8 strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+Fix md5 hash for utf8 strings
+
 ## 1.0.3
 
 Added custom toString method.

--- a/lib/simple_gravatar.dart
+++ b/lib/simple_gravatar.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:crypto/crypto.dart';
 
 enum GravatarImage {
@@ -25,10 +27,8 @@ class Gravatar {
   Gravatar(this.email) : this.hash = _generateHash(email);
 
   static String _generateHash(String email) {
-    String preparedEmail = (email.trim()).toLowerCase();
-    Digest digest = (md5.convert(preparedEmail.codeUnits));
-
-    return digest.toString();
+    String preparedEmail = email.trim().toLowerCase();
+    return md5.convert(utf8.encode(preparedEmail)).toString();
   }
 
   String imageUrl({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: simple_gravatar
-version: 1.0.3
+version: 1.0.4
 author: Alif Rachmawadi <arch@subosito.com>
 description: A library to generate Gravatar URL in Dart 2 based on gravatar specs.
 homepage: https://github.com/subosito/simple_gravatar


### PR DESCRIPTION
PHP produces a different md5 hash than dart for utf8 strings. As there are email addresses with utf8 characters (e.g. ...@राजस्थान.भारत), dart's md5 algorithm must produce the same hash as php's.